### PR TITLE
Endpoint to render HTML book description from markdown source #82

### DIFF
--- a/books/urls.py
+++ b/books/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     path('generate_data_json', views.generate_data_json),
     path('update_read_by_author_tag', views.update_read_by_author_tag),
     path('stats/birthdays', views.birthdays),
+    path('markdown_preview', views.markdown_to_html)
 ]

--- a/books/views.py
+++ b/books/views.py
@@ -9,6 +9,7 @@ from django import views
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.views.decorators.cache import cache_control
+from django.views.decorators.http import require_POST
 from django.shortcuts import render, get_object_or_404, redirect
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
@@ -512,14 +513,11 @@ def birthdays(request: HttpRequest) -> HttpResponse:
     return render(request, 'books/stats/birthdays.html', context)
 
 
+@require_POST
 def markdown_to_html(request: HttpRequest) -> HttpResponse:
     '''Markdown to HTML'''
-    if request.method == 'POST':
-        markdown_text = request.body.decode('utf-8')
-        if markdown_text:
-            html_text = markdownify(markdown_text, custom_settings="book_description")
-            return HttpResponse(
-                content=html_text,
-                content_type='text/html',
-                headers={'Access-Control-Allow-Origin': '*'})
-    return HttpResponse(content="Bad request", content_type='text/plain', status=400)
+    markdown_text = request.body.decode('utf-8')
+    if not markdown_text:
+        return HttpResponse(content="Bad request", content_type='text/plain', status=400)
+    html_text = markdownify(markdown_text, custom_settings="book_description")
+    return HttpResponse(content=html_text, content_type='text/html', headers={'Access-Control-Allow-Origin': '*'})

--- a/books/views.py
+++ b/books/views.py
@@ -518,6 +518,6 @@ def markdown_to_html(request: HttpRequest) -> HttpResponse:
     '''Markdown to HTML'''
     markdown_text = request.body.decode('utf-8')
     if not markdown_text:
-        return HttpResponse(content="Bad request", content_type='text/plain', status=400)
+        return HttpResponse(content="Request body is empty", content_type='text/plain', status=400)
     html_text = markdownify(markdown_text, custom_settings="book_description")
     return HttpResponse(content=html_text, content_type='text/html', headers={'Access-Control-Allow-Origin': '*'})

--- a/books/views.py
+++ b/books/views.py
@@ -17,6 +17,7 @@ from django.core.management import call_command
 from django.urls import reverse
 from django.db.models import query
 from algoliasearch.search_client import SearchClient
+from markdownify.templatetags.markdownify import markdownify
 
 from books import serializers
 from books.templatetags.books_extras import to_human_language
@@ -509,3 +510,16 @@ def birthdays(request: HttpRequest) -> HttpResponse:
         'people_with_info': people_with_info,
     }
     return render(request, 'books/stats/birthdays.html', context)
+
+
+def markdown_to_html(request: HttpRequest) -> HttpResponse:
+    '''Markdown to HTML'''
+    if request.method == 'POST':
+        markdown_text = request.body.decode('utf-8')
+        if markdown_text:
+            html_text = markdownify(markdown_text, custom_settings="book_description")
+            return HttpResponse(
+                content=html_text,
+                content_type='text/html',
+                headers={'Access-Control-Allow-Origin': '*'})
+    return HttpResponse(content="Bad request", content_type='text/plain', status=400)


### PR DESCRIPTION
This is only backend half of required work. I would be happy if anybody could help with customization admin change/add book page to embed dynamically updated preview field 

Backend render interface:
```
POST /markdown_preview
Request Body: <markdown text>
Response Body: <html text>
```

@nbeloglazov 
Let me know if you wish to make it JSON-like, or admin authorized only. But it may bring some additional complexity for frontend with escaping special characters and making authorized requests