### PR TITLE
Enable App Engine warmup requests

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -13,4 +13,7 @@ handlers:
 - url: /.*
   script: auto
   secure: always
+# Enable warmup requests to prepare instance for production load
+inbound_services:
+- warmup
 # [END django_app]

--- a/books/urls.py
+++ b/books/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('robots.txt', support.robots_txt),
     path('sitemap.txt', support.sitemap),
     path('data.json', support.get_data_json),
+    path('_ah/warmup', support.get_data_json),
     path('job/push_data_to_algolia', support.push_data_to_algolia),
     path('job/generate_data_json', support.generate_data_json),
     path('job/update_read_by_author_tag', support.update_read_by_author_tag),

--- a/books/urls.py
+++ b/books/urls.py
@@ -23,10 +23,10 @@ urlpatterns = [
     path('robots.txt', support.robots_txt),
     path('sitemap.txt', support.sitemap),
     path('data.json', support.get_data_json),
+    path('job/push_data_to_algolia', support.push_data_to_algolia),
     # /_ah/warmup - App Engine specific endpoint to pre-warm application for traffic
     # https://cloud.google.com/appengine/docs/standard/configuring-warmup-requests?tab=python#enabling_warmup_requests
-    path('_ah/warmup', support.get_data_json),
-    path('job/push_data_to_algolia', support.push_data_to_algolia),
+    path('_ah/warmup', support.generate_data_json),
     path('job/generate_data_json', support.generate_data_json),
     path('job/update_read_by_author_tag', support.update_read_by_author_tag),
     path('job/sync_image_cache', support.sync_image_cache),

--- a/books/urls.py
+++ b/books/urls.py
@@ -23,6 +23,8 @@ urlpatterns = [
     path('robots.txt', support.robots_txt),
     path('sitemap.txt', support.sitemap),
     path('data.json', support.get_data_json),
+    # /_ah/warmup - App Engine specific endpoint to pre-warm application for traffic
+    # https://cloud.google.com/appengine/docs/standard/configuring-warmup-requests?tab=python#enabling_warmup_requests
     path('_ah/warmup', support.get_data_json),
     path('job/push_data_to_algolia', support.push_data_to_algolia),
     path('job/generate_data_json', support.generate_data_json),


### PR DESCRIPTION
Part I of #129 

What is that: https://cloud.google.com/appengine/docs/standard/configuring-warmup-requests?tab=python

We need that for correct behavior of: 
```
automatic_scaling:
    min_instances: 1
```
See: https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=python#scaling_elements