### PR TITLE
Issue 112: Use preview_url field from Narration model to render book details page

### DIFF
--- a/templates/books/book-detail.html
+++ b/templates/books/book-detail.html
@@ -84,11 +84,6 @@
                 {% endif %}
                 {% cite_source book.description_source "cit-description" %}
             </div>
-
-            {% if book.preview_url %}
-                {% translate "Першую частку можна паслухаць бясплатна на" %} <a href="{{ book.preview_url }}" target="_blank">YouTube</a>.
-            {% endif %}
-
             {% if book.livelib_url %}
             <div class="mb-4">
                 {% translate "Водгукі на" %} <a href="{{ book.livelib_url }}" target="_blank">LiveLib</a>
@@ -139,6 +134,9 @@
                         {% dtranslate narration.description as narration_description %}
                         {{ narration_description | markdownify:"book_description" | linebreaks }}
                     </div>
+                {% endif %}
+                {% if narration.paid and narration.preview_url %}
+                        <div class="my-4" data-test="narration-description">{% translate "Першую частку можна паслухаць бясплатна на" %} <a href="{{ narration.preview_url }}" target="_blank">YouTube</a>.</div>
                 {% endif %}
                 <strong>
                 {% if narration.paid %}

--- a/tests/tests_book_page.py
+++ b/tests/tests_book_page.py
@@ -145,6 +145,16 @@ class BookPageTests(WebdriverTestCase):
         header = self.driver.find_element(By.CSS_SELECTOR, '.links-header')
         self.assertIn('Дзе купіць', header.text)
 
+    def test_book_with_paid_narration_and_and_preview_url_has_link(self):
+        narration = self.book.narrations.first()
+        narration.paid = True
+        narration.preview_url = "https://youtube.com/ttt"
+        narration.save()
+        self.driver.get(self._get_book_url())
+        elem = self.driver.find_element(By.LINK_TEXT, "YouTube")
+        self.assertEqual('https://youtube.com/ttt',
+                         elem.get_attribute("href"))
+
     def test_russian_only_books_show_both_titles(self):
         self.book.title = 'Першая кніга'
         self.book.title_ru = 'Первая книга'


### PR DESCRIPTION
#112  Use preview_url field from Narration model to render book details page

<img width="1056" alt="image" src="https://github.com/belaudiobooks/website/assets/8971400/5940ce9e-31a2-41bb-bc6b-06a65d87140a">

